### PR TITLE
fix crash from fresh clone - incorrect styles

### DIFF
--- a/screens/GameScreen.vue
+++ b/screens/GameScreen.vue
@@ -313,7 +313,6 @@ export default {
 
 <style scoped>
 .container {
-  flex: auto;
   background-color: white;
   align-items: center;
   justify-content: center;
@@ -367,7 +366,6 @@ export default {
     height: 40px;
 }
 .progress-dots {
-    vertical-align: center;
     border-width: 2px;
     width: 20; 
     height: 45;


### PR DESCRIPTION
when trying to `npm install && npm start` from a fresh clone, it would error out saying that these styles didn't exist.