### PR TITLE
countdown timer with colored bar instead of text

### DIFF
--- a/screens/GameScreen.vue
+++ b/screens/GameScreen.vue
@@ -4,9 +4,16 @@
             <view block 
                 :class="['score-text-box', is_expert_mode? 'space-between' : 'justify-right']"
             >
+                <view v-if="is_expert_mode" :style="{flex: 1, flexDirection: 'row', justifyContent: 'flex-start', width: '20%'}">
                 <nb-text :style="{
                             marginTop: 14
-                        }" v-if="is_expert_mode">Time: {{time}}</nb-text>
+                            }">Time: </nb-text>
+                    <nb-text :style="{
+                                marginTop: 14,
+                                color: timer_color,
+                            }"
+                    >{{timer_blocks}}</nb-text>
+                </view>
                 <view :style="{flex: 1, flexDirection: 'row', justifyContent: 'flex-end', width: '20%'}">
                     <nb-text
                         :style="{
@@ -147,7 +154,14 @@ export default {
         success_color: variables.brandSuccess,
         fail_color: variables.brandDanger,
         time: 0,
-        timerid: []
+        timerid: [],
+        lost: false,
+        timer_colors: [
+            "#cc1111",
+            "#ee9922",
+            "#dddd11",
+            "#22dd22",
+        ],
     },
     computed: {
         question() {
@@ -160,6 +174,12 @@ export default {
         },
         is_expert_mode() {
             return this.navigation.getParam('expert');
+        },
+        timer_color() {
+            return this.timer_colors[this.time]
+        },
+        timer_blocks() {
+            return this.time==0? "│" : "█".repeat(this.time)
         }
     },
     created() {


### PR DESCRIPTION
how about a bar that shrinks and changes color as the timer goes down so that it's more visible in your peripherals?
![timer bar](https://user-images.githubusercontent.com/17536161/66278809-08444e00-e8f0-11e9-97b6-3d7035377dd6.gif)
